### PR TITLE
fix partial bind

### DIFF
--- a/SortedListAdapter/src/main/java/com/github/wrdlbrnft/sortedlistadapter/SortedListAdapter.java
+++ b/SortedListAdapter/src/main/java/com/github/wrdlbrnft/sortedlistadapter/SortedListAdapter.java
@@ -114,10 +114,11 @@ public abstract class SortedListAdapter<T extends SortedListAdapter.ViewModel> e
 
     @Override
     public void onBindViewHolder(ViewHolder<? extends T> holder, int position, List<Object> payloads) {
-        super.onBindViewHolder(holder, position, payloads);
         final T item = mSortedList.get(position);
         if(payloads.size() > 0)
             ((ViewHolder<T>) holder).bindPartial(item, payloads);
+        else
+            ((ViewHolder<T>) holder).bind(item);
     }
 
     public final Editor<T> edit() {


### PR DESCRIPTION
old behavior: would do a full bind in the super.onBind call and then do a partial bind
new behavior: do a partial bind if the payloads are not empty. otherwise full bind